### PR TITLE
Release v0.1.1

### DIFF
--- a/pexels/Cargo.toml
+++ b/pexels/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pexels"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Pexels CLI"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
$Fixes #26\n\nBumps pexels crate version from 0.1.0 to 0.1.1 to prepare release. No other changes.